### PR TITLE
Fix mqttServer String

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -55,7 +55,10 @@ module.exports = NodeHelper.create({
 
         var self = this;
 
-        var mqttServer = (server.address.match(/^mqtts?:\/\//) ? '' : 'mqtt://') + server.address + ':' server.port+ ;
+        var mqttServer = (server.address.match(/^mqtts?:\/\//) ? '' : 'mqtt://') + server.address;
+        if (server.port) {
+            mqttServer = mqttServer + ':' + server.port
+        }
         console.log(self.name + ': Connecting to ' + mqttServer);
 
         server.client = mqtt.connect(mqttServer, server.options);

--- a/node_helper.js
+++ b/node_helper.js
@@ -55,7 +55,7 @@ module.exports = NodeHelper.create({
 
         var self = this;
 
-        var mqttServer = (server.address.match(/^mqtts?:\/\//) ? '' : 'mqtt://') + server.address;
+        var mqttServer = (server.address.match(/^mqtts?:\/\//) ? '' : 'mqtt://') + server.address + ':' server.port+ ;
         console.log(self.name + ': Connecting to ' + mqttServer);
 
         server.client = mqtt.connect(mqttServer, server.options);


### PR DESCRIPTION
When trying to connect to a mqtt cloud broker (e.g. cloudmqtt) I need to configure hostname, port, user, password. 
In this case the string of the server is not assembled correctly. The port is missing.
With this fix the port will be appended to the server string and the connection works immediately.