### PR TITLE
Add broker CA cert option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config.js
 
 .vscode/
 coverage
+/.scannerwork/
+*.crt

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Here is an example configuration with description. Put it in the `MagicMirror/co
         useWildcards: false,
         mqttServers: [
             {
-                address: 'localhost',  // Server address or IP address
-                port: '1883',          // Port number if other than default
-                user: 'user',          // Leave out for no user
-                password: 'password',  // Leave out for no password
+                address: 'localhost',          // Server address or IP address
+                port: '1883',                  // Port number if other than default
+                // ca: '/path/to/ca/cert.crt', // Path to trusted CA certificate file (optional)
+                user: 'user',                  // Leave out for no user
+                password: 'password',          // Leave out for no password
                 subscriptions: [
                     {
                         topic: 'smoky/1/inside/temperature', // Topic to look for

--- a/node_helper.js
+++ b/node_helper.js
@@ -31,7 +31,11 @@ module.exports = NodeHelper.create({
     };
 
     if (notification === "MQTT_CONFIG") {
-      this.servers = mqttHelper.addServers(this.servers, payload.mqttServers);
+      this.servers = mqttHelper.addServers(
+        this.servers,
+        payload.mqttServers,
+        this.name
+      );
       this.logging = payload.logging;
 
       // Start clients

--- a/test/__snapshots__/module.test.js.snap
+++ b/test/__snapshots__/module.test.js.snap
@@ -108,5 +108,18 @@ exports[`MMM-MQTT module renders all fetures 1`] = `
       class="align-left mqtt-suffix"
     />
   </tr>
+  <tr>
+    <td
+      class="align-left mqtt-label"
+    >
+      Topic 1 value
+    </td>
+    <td
+      class="align-right medium mqtt-value bright"
+    />
+    <td
+      class="align-left mqtt-suffix"
+    />
+  </tr>
 </table>
 `;

--- a/test/cert.txt
+++ b/test/cert.txt
@@ -1,0 +1,1 @@
+TEST CERT

--- a/test/test_servers.js
+++ b/test/test_servers.js
@@ -1,3 +1,4 @@
+const path = require("path");
 module.exports = [
   {
     address: "server1",
@@ -57,6 +58,19 @@ module.exports = [
           { from: "true", to: "Open" },
           { from: "false", to: "Closed" }
         ]
+      }
+    ]
+  },
+  {
+    address: "mqtts://server3",
+    port: "12345",
+    user: "myuser",
+    password: "mypassword",
+    ca: __dirname + path.sep + "cert.txt",
+    subscriptions: [
+      {
+        topic: "topic1/value",
+        label: "Topic 1 value"
       }
     ]
   }


### PR DESCRIPTION
Although this module already allows mqtts connections, these connections fail if a private PKI is used to sign the MQTT broker's certificate.

This change allows for a custom CA certificate file to be specified in the config, allowing MMM-MQTT to trust the certificate presented by the MQTT broker.