### PR TITLE
Add MQTT ClientId option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here is an example configuration with description. Put it in the `MagicMirror/co
                 address: 'localhost',          // Server address or IP address
                 port: '1883',                  // Port number if other than default
                 // ca: '/path/to/ca/cert.crt', // Path to trusted CA certificate file (optional)
+                // clientId: 'mirror',         // Custom MQTT client ID (optional)
                 user: 'user',                  // Leave out for no user
                 password: 'password',          // Leave out for no password
                 subscriptions: [

--- a/mqtt_helper.js
+++ b/mqtt_helper.js
@@ -27,6 +27,7 @@ const addServer = function (servers, server, name) {
         console.log(name + ": Error accessing CA file: " + err);
       }
     }
+  if (server.clientId) mqttServer.options.clientId = server.clientId;
   mqttServer.topics.push(
     ...server.subscriptions
       .map((sub) => sub.topic)

--- a/test/mqtt_helper.test.js
+++ b/test/mqtt_helper.test.js
@@ -50,7 +50,8 @@ describe("mqtt handling", () => {
         options: {
           password: "mypassword",
           username: "myuser",
-          ca: Buffer.from("TEST CERT")
+          ca: Buffer.from("TEST CERT"),
+          clientId: "customclientid"
         },
         serverKey: "mqtts://server3:12345myuser",
         topics: ["topic1/value"]
@@ -73,7 +74,8 @@ describe("mqtt handling", () => {
     expect(mqttMock.connect).toHaveBeenCalledWith("mqtts://server3:12345", {
       password: "mypassword",
       username: "myuser",
-      ca: Buffer.from("TEST CERT")
+      ca: Buffer.from("TEST CERT"),
+      clientId: "customclientid"
     });
     expect(console.log).toHaveBeenCalledWith(
       "MMM-MQTT: Connecting to mqtt://server1:12345"

--- a/test/test_servers.js
+++ b/test/test_servers.js
@@ -67,6 +67,7 @@ module.exports = [
     user: "myuser",
     password: "mypassword",
     ca: __dirname + path.sep + "cert.txt",
+    clientId: "customclientid",
     subscriptions: [
       {
         topic: "topic1/value",


### PR DESCRIPTION
The MQTT client ID is currently set as per the mqtt.js default: 'mqttjs_' + Math.random().toString(16).substr(2, 8)

This change adds the option to specify a custom client ID in the config.js file, if required. This can make it easier to differentiate between clients when looking through the logs of the MQTT broker.