### PR TITLE
add option for cert and private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Here is an example configuration with description. Put it in the `MagicMirror/co
         address: 'localhost',  // Server address or IP address
         port: '1883',          // Port number if other than default
         // ca: '/path/to/ca/cert.crt', // Path to trusted CA certificate file (optional)
+		// cert: '/path/to/cert/cert.crt', // Path to cert certificate file (optional)
+		// key: '/path/to/key/private.key', // Path to private key file (optional)
+		// allowUnauthorized: true, // Allow unauthorized connections for self signed certificates (optional)
         // clientId: 'mirror',     // Custom MQTT client ID (optional)
         user: 'user',          // Leave out for no user
         password: 'password',      // Leave out for no password

--- a/mqtt_helper.js
+++ b/mqtt_helper.js
@@ -28,6 +28,33 @@ const addServer = function (servers, server, name) {
         console.log(name + ": Error accessing CA file: " + err);
       }
     }
+  if(server.cert) 
+    try {
+      mqttServer.options.cert = fs.readFileSync(server.cert);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        console.log(name + ": Cert file not found!");
+      } else if (err.code === "EACCES") {
+        console.log(name + ": Cert file permissions issue!");
+      } else {
+        console.log(name + ": Error accessing cert file: " + err);
+      }
+    }
+  if(server.key) 
+    try {
+      mqttServer.options.key = fs.readFileSync(server.key);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        console.log(name + ": Key file not found!");
+      } else if (err.code === "EACCES") {
+        console.log(name + ": Key file permissions issue!");
+      } else {
+        console.log(name + ": Error accessing key file: " + err);
+      }
+    }
+  if (server.allowUnauthorized)
+    mqttServer.options.rejectUnauthorized = false;
+
   if (server.clientId) mqttServer.options.clientId = server.clientId;
   mqttServer.topics.push(
     ...server.subscriptions


### PR DESCRIPTION
I added an option for a cert and private key file to connect securely to the MQTT broker. To allow connections using self signed certificates I added `allowUnauthorized`