### PR TITLE
feat: add unconditional single color setting

### DIFF
--- a/MMM-MQTT.js
+++ b/MMM-MQTT.js
@@ -145,14 +145,17 @@ Module.register("MMM-MQTT", {
     }
 
     let colors;
-    for (i = 0; i < sub.colors.length; i++) {
-      colors = sub.colors[i];
-      if (sub.value < sub.colors[i].upTo) {
-        break;
-      }
+    if (!Array.isArray(sub.colors)) {
+        colors = sub.colors
+    } else {
+        for (i = 0; i < sub.colors.length; i++) {
+            colors = sub.colors[i];
+            if (sub.value < sub.colors[i].upTo) {
+                break;
+            }
+        }
     }
-
-    return colors;
+  return colors;
   },
 
   multiply: function (sub, value) {

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ conversions: [
 
 ### Colored values
 
+Value-independet colors can be defined like this:
+
+```javascript
+colors: {value: "#caccca", label: "green", suffix: "pink"},
+```
+
 For numeric values, color codes can be configured using the colors array in the subscription config.
 If you are using the same color scheme on multiple topics, you can configure it as a constant above the config variable like this:
 


### PR DESCRIPTION
I added a way to style the display of a payload independently of a numerical value. Also modified the ReadMe accordingly.